### PR TITLE
Fix: Ensure layout constraints are available before initializing PDF …

### DIFF
--- a/app/src/main/java/eka/care/documents/ui/components/smartreport/RecordPreviewComponents.kt
+++ b/app/src/main/java/eka/care/documents/ui/components/smartreport/RecordPreviewComponents.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -116,16 +117,20 @@ fun RecordSuccessState(
 
                 onUriSelected(uri)
 
-                val pdfVerticalReaderState = rememberVerticalPdfReaderState(
-                    resource = ResourceType.Local(uri),
-                    isZoomEnable = true
-                )
-                VerticalPDFReader(
-                    state = pdfVerticalReaderState,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(color = Color.Gray)
-                )
+                BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                    if (constraints.maxWidth > 0) {
+                        val pdfVerticalReaderState = rememberVerticalPdfReaderState(
+                            resource = ResourceType.Local(uri),
+                            isZoomEnable = true
+                        )
+                        VerticalPDFReader(
+                            state = pdfVerticalReaderState,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(color = Color.Gray)
+                        )
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/eka/care/documents/ui/screens/AddRecordPreviewScreen.kt
+++ b/app/src/main/java/eka/care/documents/ui/screens/AddRecordPreviewScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -249,16 +250,20 @@ fun PreviewComponent(
                         }
                     }
                 } else {
-                    val pdfVerticalReaderState = rememberVerticalPdfReaderState(
-                        resource = ResourceType.Local(pdfUriString.toUri()),
-                        isZoomEnable = true
-                    )
-                    VerticalPDFReader(
-                        state = pdfVerticalReaderState,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(color = Color.Gray)
-                    )
+                    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                        if (constraints.maxWidth > 0) {
+                            val pdfVerticalReaderState = rememberVerticalPdfReaderState(
+                                resource = ResourceType.Local(pdfUriString.toUri()),
+                                isZoomEnable = true
+                            )
+                            VerticalPDFReader(
+                                state = pdfVerticalReaderState,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .background(color = Color.Gray)
+                            )
+                        }
+                    }
                 }
             }
         },


### PR DESCRIPTION
…reader

This commit wraps the `VerticalPDFReader` within a `BoxWithConstraints` to ensure that valid layout dimensions are available before attempting to render a PDF. This prevents potential initialization issues or crashes occurring when the reader is instantiated with zero-width constraints.

- **PDF Rendering Stability:**
    - Updated `RecordPreviewComponents.kt` to wrap the PDF reader in `BoxWithConstraints` and verify `constraints.maxWidth > 0`.
    - Updated `AddRecordPreviewScreen.kt` with the same constraint check logic to guard the `VerticalPDFReader` initialization.