### PR TITLE
Refactor: Use Gson for parameter parsing in AddRecordPreviewActivity

### DIFF
--- a/app/src/main/java/eka/care/documents/ui/activity/AddRecordPreviewActivity.kt
+++ b/app/src/main/java/eka/care/documents/ui/activity/AddRecordPreviewActivity.kt
@@ -39,16 +39,9 @@ class AddRecordPreviewActivity : ComponentActivity() {
         val jsonString = intent.getStringExtra(AddRecordParams.PARAMS_KEY)
         if (jsonString.isNullOrEmpty()) {
             Log.e("AddPreviewActivity", "Params JSON is missing!")
-            finish()
             return
         }
-        params = try {
-            JSONObject(jsonString)
-        } catch (e: Exception) {
-            Log.e("AddPreviewActivity", "Failed to parse params JSON", e)
-            finish()
-            return
-        }
+        params = Gson().fromJson(jsonString, JSONObject::class.java)
 
         val navData = AddRecordPreviewNavModel(
             pdfUriString = if (params.has(AddRecordParams.PDF_URI.key)) params.getString(AddRecordParams.PDF_URI.key) else null,


### PR DESCRIPTION
This commit simplifies the initialization of navigation parameters by replacing manual `JSONObject` parsing with `Gson`. It also updates the error handling flow by removing explicit activity termination during initial parameter validation.

- **Data Parsing:**
    - Updated `AddRecordPreviewActivity` to use `Gson().fromJson` for converting the intent's JSON string into the `params` object.
    - Removed the `try-catch` block previously required for manual JSON parsing.
- **Validation Logic:**
    - Removed `finish()` calls when the input `jsonString` is null or empty, streamlining the validation check.